### PR TITLE
feat: 회원 설정 및 로그아웃 구현 (Closes #20)

### DIFF
--- a/backend/src/main/java/com/benepicker/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/benepicker/auth/controller/AuthController.java
@@ -1,0 +1,16 @@
+package com.benepicker.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/benepicker/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/benepicker/auth/controller/AuthController.java
@@ -1,5 +1,10 @@
 package com.benepicker.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -7,8 +12,23 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
+    @Operation(
+            summary = "로그아웃",
+            description = """
+			로그인한 회원을 로그아웃 처리합니다.
+			
+			현재 구조에서는 서버가 별도의 세션을 저장하지 않으므로
+			클라이언트에서 AccessToken 삭제 및 AsyncStorage 초기화를 함께 수행해야 합니다.
+			""",
+            security = @SecurityRequirement(name = "BearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
     @PostMapping("/logout")
     public ResponseEntity<Void> logout() {
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/benepicker/member/controller/MemberController.java
+++ b/backend/src/main/java/com/benepicker/member/controller/MemberController.java
@@ -2,6 +2,11 @@ package com.benepicker.member.controller;
 
 import java.util.Map;
 
+import com.benepicker.common.auth.dto.CustomUserDetails;
+import com.benepicker.member.dto.request.UpdatePasswordRequest;
+import com.benepicker.member.dto.request.UpdatePrivacyRequest;
+import com.benepicker.member.dto.request.UpdateProfileRequest;
+import com.benepicker.member.dto.response.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +27,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Member", description = "회원 관련 API")
 @RestController
@@ -171,5 +178,39 @@ public class MemberController {
     ) {
         int count = memberService.checkNickname(memberNickname);
         return ResponseEntity.ok(Map.of("available", count == 0));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberInfoResponse> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(memberService.getMyInfo(userDetails.getMemberNo()));
+    }
+
+    @PatchMapping("/me/profile")
+    public ResponseEntity<Void> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdateProfileRequest request
+    ) {
+        memberService.updateProfile(userDetails.getMemberNo(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdatePasswordRequest request
+    ) {
+        memberService.updatePassword(userDetails.getMemberNo(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/privacy")
+    public ResponseEntity<Void> updatePrivacy(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdatePrivacyRequest request
+    ) {
+        memberService.updatePrivacy(userDetails.getMemberNo(), request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/benepicker/member/controller/MemberController.java
+++ b/backend/src/main/java/com/benepicker/member/controller/MemberController.java
@@ -197,7 +197,7 @@ public class MemberController {
                     - 개인정보 동의 여부
                     - 마케팅 동의 여부
                     """,
-            security = @SecurityRequirement(name = "bearerAuth")
+            security = @SecurityRequirement(name = "BearerAuth")
     )
     @ApiResponses({
             @ApiResponse(
@@ -226,7 +226,7 @@ public class MemberController {
                     - 이름
                     - 프로필 이미지 URL
                     """,
-            security = @SecurityRequirement(name = "bearerAuth")
+            security = @SecurityRequirement(name = "BearerAuth")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
@@ -255,7 +255,7 @@ public class MemberController {
                     
                     현재 비밀번호가 일치해야 변경할 수 있습니다.
                     """,
-            security = @SecurityRequirement(name = "bearerAuth")
+            security = @SecurityRequirement(name = "BearerAuth")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),

--- a/backend/src/main/java/com/benepicker/member/controller/MemberController.java
+++ b/backend/src/main/java/com/benepicker/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.benepicker.member.dto.request.UpdatePasswordRequest;
 import com.benepicker.member.dto.request.UpdatePrivacyRequest;
 import com.benepicker.member.dto.request.UpdateProfileRequest;
 import com.benepicker.member.dto.response.MemberInfoResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,11 +51,11 @@ public class MemberController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-					{
-					  "accessToken": "sample-access-token",
-					  "refreshToken": "sample-refresh-token"
-					}
-					"""
+                                            {
+                                              "accessToken": "sample-access-token",
+                                              "refreshToken": "sample-refresh-token"
+                                            }
+                                            """
                             )
                     )
             ),
@@ -71,11 +72,11 @@ public class MemberController {
                             schema = @Schema(implementation = Map.class),
                             examples = @ExampleObject(
                                     value = """
-					{
-					  "memberEmail": "test@example.com",
-					  "memberPw": "1234"
-					}
-					"""
+                                            {
+                                              "memberEmail": "test@example.com",
+                                              "memberPw": "1234"
+                                            }
+                                            """
                             )
                     )
             )
@@ -105,12 +106,12 @@ public class MemberController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-					{
-					  "memberEmail": "test@example.com",
-					  "memberPw": "1234",
-					  "memberNickname": "정환"
-					}
-					"""
+                                            {
+                                              "memberEmail": "test@example.com",
+                                              "memberPw": "1234",
+                                              "memberNickname": "정환"
+                                            }
+                                            """
                             )
                     )
             )
@@ -134,10 +135,10 @@ public class MemberController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-					{
-					  "available": true
-					}
-					"""
+                                            {
+                                              "available": true
+                                            }
+                                            """
                             )
                     )
             )
@@ -163,10 +164,10 @@ public class MemberController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-					{
-					  "available": true
-					}
-					"""
+                                            {
+                                              "available": true
+                                            }
+                                            """
                             )
                     )
             )
@@ -180,15 +181,62 @@ public class MemberController {
         return ResponseEntity.ok(Map.of("available", count == 0));
     }
 
+    @Operation(
+            summary = "내 정보 조회",
+            description = """
+                    로그인한 회원의 설정 정보를 조회합니다.
+                    
+                    조회 항목:
+                    - 이메일
+                    - 닉네임
+                    - 이름
+                    - 전화번호
+                    - 프로필 이미지
+                    - 생년월일
+                    - 성별
+                    - 개인정보 동의 여부
+                    - 마케팅 동의 여부
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
+    })
     @GetMapping("/me")
     public ResponseEntity<MemberInfoResponse> getMyInfo(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return ResponseEntity.ok(memberService.getMyInfo(userDetails.getMemberNo()));
     }
 
+    @Operation(
+            summary = "프로필 수정",
+            description = """
+                    로그인한 회원의 프로필 정보를 수정합니다.
+                    
+                    수정 가능 항목:
+                    - 닉네임
+                    - 이름
+                    - 프로필 이미지 URL
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
+    })
     @PatchMapping("/me/profile")
     public ResponseEntity<Void> updateProfile(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UpdateProfileRequest request
     ) {
@@ -196,8 +244,28 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "비밀번호 변경",
+            description = """
+                    로그인한 회원의 비밀번호를 변경합니다.
+                    
+                    요청 값:
+                    - 현재 비밀번호
+                    - 새 비밀번호
+                    
+                    현재 비밀번호가 일치해야 변경할 수 있습니다.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치 또는 잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
+    })
     @PatchMapping("/me/password")
     public ResponseEntity<Void> updatePassword(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UpdatePasswordRequest request
     ) {
@@ -205,8 +273,29 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "개인정보 수정",
+            description = """
+                    로그인한 회원의 개인정보를 수정합니다.
+                    
+                    수정 가능 항목:
+                    - 전화번호
+                    - 생년월일
+                    - 성별
+                    - 개인정보 수집 및 이용 동의 여부
+                    - 마케팅 수신 동의 여부
+                    """,
+            security = @SecurityRequirement(name = "BearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "개인정보 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
+    })
     @PatchMapping("/me/privacy")
     public ResponseEntity<Void> updatePrivacy(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UpdatePrivacyRequest request
     ) {

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdatePasswordRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,11 @@
+package com.benepicker.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePasswordRequest {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdatePasswordRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdatePasswordRequest.java
@@ -1,11 +1,17 @@
 package com.benepicker.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "비밀번호 변경 요청")
 public class UpdatePasswordRequest {
+
+    @Schema(description = "현재 비밀번호", example = "oldPassword123!")
     private String currentPassword;
+
+    @Schema(description = "새 비밀번호", example = "newPassword123!")
     private String newPassword;
 }

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
@@ -1,0 +1,14 @@
+package com.benepicker.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePrivacyRequest {
+    private String memberTel;
+    private String birthDate;
+    private String gender;
+    private String privacyAgreeFl;
+    private String marketingAgreeFl;
+}

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
@@ -1,14 +1,26 @@
 package com.benepicker.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "개인정보 수정 요청")
 public class UpdatePrivacyRequest {
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
     private String memberTel;
+
+    @Schema(description = "생년월일", example = "2000-01-01")
     private String birthDate;
+
+    @Schema(description = "성별", example = "MALE")
     private String gender;
+
+    @Schema(description = "개인정보 동의 여부", example = "Y")
     private String privacyAgreeFl;
+
+    @Schema(description = "마케팅 동의 여부", example = "N")
     private String marketingAgreeFl;
 }

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdatePrivacyRequest.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @NoArgsConstructor
 @Schema(description = "개인정보 수정 요청")
@@ -13,7 +15,7 @@ public class UpdatePrivacyRequest {
     private String memberTel;
 
     @Schema(description = "생년월일", example = "2000-01-01")
-    private String birthDate;
+    private LocalDate birthDate;
 
     @Schema(description = "성별", example = "MALE")
     private String gender;

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,12 @@
+package com.benepicker.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateProfileRequest {
+    private String memberNickname;
+    private String memberName;
+    private String profileImageUrl;
+}

--- a/backend/src/main/java/com/benepicker/member/dto/request/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/benepicker/member/dto/request/UpdateProfileRequest.java
@@ -1,12 +1,20 @@
 package com.benepicker.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "프로필 수정 요청")
 public class UpdateProfileRequest {
+
+    @Schema(description = "닉네임", example = "혜택왕")
     private String memberNickname;
+
+    @Schema(description = "이름", example = "이정환")
     private String memberName;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
     private String profileImageUrl;
 }

--- a/backend/src/main/java/com/benepicker/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/benepicker/member/dto/response/MemberInfoResponse.java
@@ -1,19 +1,41 @@
 package com.benepicker.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "회원 정보 조회 응답")
 public class MemberInfoResponse {
+
+    @Schema(description = "회원 번호", example = "1")
     private Long memberNo;
+
+    @Schema(description = "회원 이메일", example = "test@benepicker.com")
     private String memberEmail;
+
+    @Schema(description = "닉네임", example = "정환")
     private String memberNickname;
+
+    @Schema(description = "이름", example = "이정환")
     private String memberName;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
     private String memberTel;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
     private String profileImageUrl;
+
+    @Schema(description = "생년월일", example = "2000-01-01")
     private String birthDate;
+
+    @Schema(description = "성별", example = "MALE")
     private String gender;
+
+    @Schema(description = "개인정보 동의 여부", example = "Y")
     private String privacyAgreeFl;
+
+    @Schema(description = "마케팅 동의 여부", example = "N")
     private String marketingAgreeFl;
 }

--- a/backend/src/main/java/com/benepicker/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/benepicker/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,19 @@
+package com.benepicker.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberInfoResponse {
+    private Long memberNo;
+    private String memberEmail;
+    private String memberNickname;
+    private String memberName;
+    private String memberTel;
+    private String profileImageUrl;
+    private String birthDate;
+    private String gender;
+    private String privacyAgreeFl;
+    private String marketingAgreeFl;
+}

--- a/backend/src/main/java/com/benepicker/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/benepicker/member/mapper/MemberMapper.java
@@ -1,5 +1,8 @@
 package com.benepicker.member.mapper;
 
+import com.benepicker.member.dto.request.UpdatePrivacyRequest;
+import com.benepicker.member.dto.request.UpdateProfileRequest;
+import com.benepicker.member.dto.response.MemberInfoResponse;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.benepicker.member.dto.Member;
@@ -16,4 +19,13 @@ public interface MemberMapper {
 
     int checkEmail(@Param("memberEmail") String memberEmail);
 
+    MemberInfoResponse selectMemberInfo(@Param("memberNo") Long memberNo);
+
+    String selectPasswordByMemberNo(@Param("memberNo") Long memberNo);
+
+    int updateProfile(@Param("memberNo") Long memberNo, @Param("request") UpdateProfileRequest request);
+
+    int updatePassword(@Param("memberNo") Long memberNo, @Param("newPassword") String newPassword);
+
+    int updatePrivacy(@Param("memberNo") Long memberNo, @Param("request") UpdatePrivacyRequest request);
 }

--- a/backend/src/main/java/com/benepicker/member/service/MemberService.java
+++ b/backend/src/main/java/com/benepicker/member/service/MemberService.java
@@ -3,15 +3,26 @@ package com.benepicker.member.service;
 import java.util.Map;
 
 import com.benepicker.member.dto.Member;
+import com.benepicker.member.dto.request.UpdatePasswordRequest;
+import com.benepicker.member.dto.request.UpdatePrivacyRequest;
+import com.benepicker.member.dto.request.UpdateProfileRequest;
+import com.benepicker.member.dto.response.MemberInfoResponse;
 
 public interface MemberService {
 
     Map<String, String> login(String memberEmail, String memberPw);
+    MemberInfoResponse getMyInfo(Long memberNo);
 
     int signup(Member member);
 
     int checkEmail(String memberEmail);
 
     int checkNickname(String memberNickname);
+
+    void updateProfile(Long memberNo, UpdateProfileRequest request);
+
+    void updatePassword(Long memberNo, UpdatePasswordRequest request);
+
+    void updatePrivacy(Long memberNo, UpdatePrivacyRequest request);
 
 }

--- a/backend/src/main/java/com/benepicker/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/com/benepicker/member/service/MemberServiceImpl.java
@@ -4,6 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.benepicker.common.util.JwtUtil;
+import com.benepicker.member.dto.request.UpdatePasswordRequest;
+import com.benepicker.member.dto.request.UpdatePrivacyRequest;
+import com.benepicker.member.dto.request.UpdateProfileRequest;
+import com.benepicker.member.dto.response.MemberInfoResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,5 +90,33 @@ public class MemberServiceImpl implements MemberService {
     @Transactional(readOnly = true)
     public int checkNickname(String memberNickname) {
         return memberMapper.checkNickname(memberNickname);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMyInfo(Long memberNo) {
+        return memberMapper.selectMemberInfo(memberNo);
+    }
+
+    @Override
+    public void updateProfile(Long memberNo, UpdateProfileRequest request) {
+        memberMapper.updateProfile(memberNo, request);
+    }
+
+    @Override
+    public void updatePassword(Long memberNo, UpdatePasswordRequest request) {
+        String encodedPassword = memberMapper.selectPasswordByMemberNo(memberNo);
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), encodedPassword)) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        String newEncodedPassword = passwordEncoder.encode(request.getNewPassword());
+        memberMapper.updatePassword(memberNo, newEncodedPassword);
+    }
+
+    @Override
+    public void updatePrivacy(Long memberNo, UpdatePrivacyRequest request) {
+        memberMapper.updatePrivacy(memberNo, request);
     }
 }

--- a/backend/src/main/resources/mappers/member-mapper.xml
+++ b/backend/src/main/resources/mappers/member-mapper.xml
@@ -104,7 +104,7 @@
         UPDATE member
         SET
         member_tel = #{request.memberTel},
-        birth_date = #{request.birthDate},
+        birth_date = #{request.birthDate, jdbcType=DATE},
         gender = #{request.gender},
         privacy_agree_fl = #{request.privacyAgreeFl},
         marketing_agree_fl = #{request.marketingAgreeFl},

--- a/backend/src/main/resources/mappers/member-mapper.xml
+++ b/backend/src/main/resources/mappers/member-mapper.xml
@@ -53,4 +53,62 @@
         WHERE MEMBER_NICKNAME = #{memberNickname}
     </select>
 
+    <!-- 회원 정보 조회 -->
+    <select id="selectMemberInfo" resultType="com.benepicker.member.dto.response.MemberInfoResponse">
+        SELECT
+        member_no AS memberNo,
+        member_email AS memberEmail,
+        member_nickname AS memberNickname,
+        member_name AS memberName,
+        member_tel AS memberTel,
+        profile_image_url AS profileImageUrl,
+        CAST(birth_date AS VARCHAR) AS birthDate,
+        gender,
+        privacy_agree_fl AS privacyAgreeFl,
+        marketing_agree_fl AS marketingAgreeFl
+        FROM member
+        WHERE member_no = #{memberNo}
+        AND member_del_fl = 'N'
+    </select>
+
+    <!-- 비밀번호 조회 -->
+    <select id="selectPasswordByMemberNo" resultType="string">
+        SELECT member_pw
+        FROM member
+        WHERE member_no = #{memberNo}
+    </select>
+
+    <!-- 프로필 업데이트 -->
+    <update id="updateProfile">
+        UPDATE member
+        SET
+        member_nickname = #{request.memberNickname},
+        member_name = #{request.memberName},
+        profile_image_url = #{request.profileImageUrl},
+        updated_date = CURRENT_TIMESTAMP
+        WHERE member_no = #{memberNo}
+    </update>
+
+    <!-- 비밀번호 변경 -->
+    <update id="updatePassword">
+        UPDATE member
+        SET
+        member_pw = #{newPassword},
+        password_updated_at = CURRENT_TIMESTAMP,
+        updated_date = CURRENT_TIMESTAMP
+        WHERE member_no = #{memberNo}
+    </update>
+
+    <!-- 개인정보 수정 -->
+    <update id="updatePrivacy">
+        UPDATE member
+        SET
+        member_tel = #{request.memberTel},
+        birth_date = #{request.birthDate},
+        gender = #{request.gender},
+        privacy_agree_fl = #{request.privacyAgreeFl},
+        marketing_agree_fl = #{request.marketingAgreeFl},
+        updated_date = CURRENT_TIMESTAMP
+        WHERE member_no = #{memberNo}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📝 작업 내용

* 회원 설정 기능 API 구현 및 Swagger 명세 추가
* 내 정보 조회, 프로필 수정, 비밀번호 변경, 개인정보 수정 기능 개발
* 로그아웃 API 추가 (클라이언트 토큰 삭제 기반)
* member 테이블에 회원 설정 관련 컬럼 확장

---

## 🔗 관련 이슈

Closes #20 

---

## 🔧 상세 변경 사항

* [x] member 테이블 컬럼 추가
  * profile_image_url, member_name, birth_date, gender 등

* [x] MemberController 추가 구현
  * GET /api/members/me (내 정보 조회)
  * PATCH /api/members/me/profile (프로필 수정)
  * PATCH /api/members/me/password (비밀번호 변경)
  * PATCH /api/members/me/privacy (개인정보 수정)

* [x] AuthController 로그아웃 API 추가
  * POST /api/auth/logout

* [x] MemberService / ServiceImpl 구현
* [x] MemberMapper 및 MyBatis XML 작성
* [x] 비밀번호 변경 시 기존 비밀번호 검증 로직 추가
* [x] 업데이트 결과(row count) 기반 예외 처리 로직 추가
* [x] Swagger 명세 추가 (@Operation, @ApiResponses 등)
* [x] DTO에 @Schema 적용하여 문서화

---

## 🧪 테스트

* [x] 내 정보 조회 정상 동작 확인
* [x] 프로필 수정 정상 반영 확인
* [x] 비밀번호 변경 성공/실패 케이스 테스트
  * 현재 비밀번호 불일치 시 예외 발생 확인

* [x] 개인정보 수정 정상 반영 확인
* [x] 인증 없이 요청 시 401 응답 확인


---

## 📸 스크린샷 (optional)

<!-- Swagger UI에서 Member API 및 Auth API 테스트 결과 첨부 -->
* 내 정보 조회
<img width="1399" height="218" alt="image" src="https://github.com/user-attachments/assets/29febe51-4f6c-40ec-acff-8b25a6b324bd" />

* 프로필 수정
<img width="1395" height="218" alt="image" src="https://github.com/user-attachments/assets/fcf3ff0d-0f75-48bb-a3ca-f57fda67930b" />

* 개인정보 수정
<img width="1399" height="209" alt="image" src="https://github.com/user-attachments/assets/d6b70306-ac7d-4fb1-b24e-313bceee7eb5" />

* 비밀번호 변경
<img width="1392" height="205" alt="image" src="https://github.com/user-attachments/assets/1c3708d6-9221-4998-a39f-f9181a6a1bc2" />

* 로그아웃
<img width="1388" height="210" alt="image" src="https://github.com/user-attachments/assets/08fb7e3e-5bab-4116-a679-069306de1343" />


---

## 💬 참고 사항

* 로그아웃은 서버에서 세션을 관리하지 않는 JWT 구조이므로
  AccessToken 삭제 및 AsyncStorage 초기화를 클라이언트에서 처리해야 합니다.
* member 테이블 컬럼은 NULL 허용으로 추가하여 기존 데이터에 영향 없이 확장했습니다.
* 로그아웃 API 호출 후 프론트에서 토큰 삭제 확인 부탁드립니다.