### PR TITLE
feat: 지도 기반 기능 구현(Closes #24)

### DIFF
--- a/backend/src/main/java/com/benepicker/map/controller/MapController.java
+++ b/backend/src/main/java/com/benepicker/map/controller/MapController.java
@@ -1,0 +1,40 @@
+package com.benepicker.map.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.benepicker.common.auth.dto.CustomUserDetails;
+import com.benepicker.map.dto.response.MapResponse;
+import com.benepicker.map.service.MapService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+@Tag(name = "Map", description = "지도 관련 API")
+public class MapController {
+
+    private final MapService mapService;
+
+    @GetMapping
+    @Operation(summary = "지도 데이터 조회", description = "현재 위치 기준 주변 매장 마커와 선택 카드 정보를 조회합니다.")
+    public ResponseEntity<MapResponse> getMapData(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam double lat,
+            @RequestParam double lng,
+            @RequestParam(defaultValue = "3") double radiusKm,
+            @RequestParam(required = false) Long selectedStoreId
+    ) {
+        Long memberNo = userDetails.getMemberNo();
+
+        MapResponse response = mapService.getMapData(memberNo, lat, lng, radiusKm, selectedStoreId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/benepicker/map/controller/MapController.java
+++ b/backend/src/main/java/com/benepicker/map/controller/MapController.java
@@ -12,19 +12,124 @@ import com.benepicker.map.dto.response.MapResponse;
 import com.benepicker.map.service.MapService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/map")
 @RequiredArgsConstructor
-@Tag(name = "Map", description = "지도 관련 API")
+@Tag(name = "Map", description = "지도 화면 관련 API")
 public class MapController {
 
     private final MapService mapService;
 
     @GetMapping
-    @Operation(summary = "지도 데이터 조회", description = "현재 위치 기준 주변 매장 마커와 선택 카드 정보를 조회합니다.")
+    @Operation(
+            summary = "지도 화면 데이터 조회",
+            description = """
+			현재 사용자 위치를 기준으로 주변 매장 마커 목록과,
+			선택한 매장의 카드형 상세 정보를 조회합니다.
+			
+			- selectedStoreId가 없으면 마커 목록만 조회됩니다.
+			- selectedStoreId가 있으면 해당 매장의 선택 카드 정보도 함께 조회됩니다.
+			- 반경(radiusKm) 내의 매장만 조회됩니다.
+			""",
+            security = @SecurityRequirement(name = "BearerAuth")
+    )
+    @Parameters({
+            @Parameter(
+                    name = "lat",
+                    description = "현재 사용자 위도",
+                    required = true,
+                    example = "37.5665"
+            ),
+            @Parameter(
+                    name = "lng",
+                    description = "현재 사용자 경도",
+                    required = true,
+                    example = "126.9780"
+            ),
+            @Parameter(
+                    name = "radiusKm",
+                    description = "조회 반경(km), 기본값 3",
+                    required = false,
+                    example = "3"
+            ),
+            @Parameter(
+                    name = "selectedStoreId",
+                    description = "선택한 매장 ID. 없으면 선택 카드 없이 마커 목록만 반환",
+                    required = false,
+                    example = "12"
+            )
+    })
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "지도 데이터 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MapResponse.class),
+                            examples = @ExampleObject(
+                                    name = "지도 조회 성공 예시",
+                                    value = """
+						{
+						  "currentLat": 37.5665,
+						  "currentLng": 126.978,
+						  "markers": [
+						    {
+						      "storeId": 1,
+						      "storeName": "스타벅스 강남점",
+						      "brandName": "스타벅스",
+						      "storeLat": 37.4979,
+						      "storeLng": 127.0276,
+						      "storeLogoUrl": "https://example.com/logo.png",
+						      "benefitType": "CARD",
+						      "benefitSummary": "아메리카노 10% 할인",
+						      "distanceKm": 0.42,
+						      "wished": true
+						    }
+						  ],
+						  "selectedCard": {
+						    "storeId": 1,
+						    "storeName": "스타벅스 강남점",
+						    "brandName": "스타벅스",
+						    "storeAddress": "서울특별시 강남구 테헤란로 00",
+						    "storeImageUrl": "https://example.com/store.png",
+						    "storeLogoUrl": "https://example.com/logo.png",
+						    "storeAppLink": "https://example.com/app",
+						    "distanceKm": 0.42,
+						    "viewCount": 123,
+						    "wished": true,
+						    "benefits": [
+						      {
+						        "benefitId": 10,
+						        "benefitType": "CARD",
+						        "benefitContent": "아메리카노 10% 할인",
+						        "benefitDiscount": 10,
+						        "benefitCondition": "OO카드 결제 시",
+						        "startDate": "2026-04-01",
+						        "endDate": "2026-04-30"
+						      }
+						    ]
+						  }
+						}
+						"""
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "선택한 매장을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<MapResponse> getMapData(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam double lat,
@@ -33,7 +138,6 @@ public class MapController {
             @RequestParam(required = false) Long selectedStoreId
     ) {
         Long memberNo = userDetails.getMemberNo();
-
         MapResponse response = mapService.getMapData(memberNo, lat, lng, radiusKm, selectedStoreId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapBenefitResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapBenefitResponse.java
@@ -1,0 +1,18 @@
+package com.benepicker.map.dto.response;
+
+import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MapBenefitResponse {
+    private Long benefitId;
+    private String benefitType;
+    private String benefitContent;
+    private Integer benefitDiscount;
+    private String benefitCondition;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapBenefitResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapBenefitResponse.java
@@ -2,17 +2,33 @@ package com.benepicker.map.dto.response;
 
 import java.time.LocalDate;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "매장 혜택 정보")
 public class MapBenefitResponse {
+
+    @Schema(description = "혜택 ID", example = "10")
     private Long benefitId;
+
+    @Schema(description = "혜택 유형", example = "CARD")
     private String benefitType;
+
+    @Schema(description = "혜택 내용", example = "아메리카노 10% 할인")
     private String benefitContent;
+
+    @Schema(description = "할인율 또는 할인 금액", example = "10")
     private Integer benefitDiscount;
+
+    @Schema(description = "혜택 조건", example = "OO카드 결제 시")
     private String benefitCondition;
+
+    @Schema(description = "혜택 시작일", example = "2026-04-01")
     private LocalDate startDate;
+
+    @Schema(description = "혜택 종료일", example = "2026-04-30")
     private LocalDate endDate;
 }

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapMarkerResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapMarkerResponse.java
@@ -1,0 +1,19 @@
+package com.benepicker.map.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MapMarkerResponse {
+    private Long storeId;
+    private String storeName;
+    private String brandName;
+    private Double storeLat;
+    private Double storeLng;
+    private String storeLogoUrl;
+    private String benefitType;
+    private String benefitSummary;
+    private Double distanceKm;
+    private Boolean wished;
+}

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapMarkerResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapMarkerResponse.java
@@ -1,19 +1,41 @@
 package com.benepicker.map.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "지도 마커 정보")
 public class MapMarkerResponse {
+
+    @Schema(description = "매장 ID", example = "1")
     private Long storeId;
+
+    @Schema(description = "매장명", example = "스타벅스 강남점")
     private String storeName;
+
+    @Schema(description = "브랜드명", example = "스타벅스")
     private String brandName;
+
+    @Schema(description = "매장 위도", example = "37.4979")
     private Double storeLat;
+
+    @Schema(description = "매장 경도", example = "127.0276")
     private Double storeLng;
+
+    @Schema(description = "매장 로고 이미지 URL", example = "https://example.com/logo.png")
     private String storeLogoUrl;
+
+    @Schema(description = "대표 혜택 유형", example = "CARD")
     private String benefitType;
+
+    @Schema(description = "대표 혜택 요약", example = "아메리카노 10% 할인")
     private String benefitSummary;
+
+    @Schema(description = "현재 위치로부터 거리(km)", example = "0.42")
     private Double distanceKm;
+
+    @Schema(description = "사용자의 찜 여부", example = "true")
     private Boolean wished;
 }

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapResponse.java
@@ -1,0 +1,15 @@
+package com.benepicker.map.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MapResponse {
+    private Double currentLat;
+    private Double currentLng;
+    private List<MapMarkerResponse> markers;
+    private MapSelectedCardResponse selectedCard;
+}

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapResponse.java
@@ -2,14 +2,24 @@ package com.benepicker.map.dto.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "지도 화면 전체 응답")
 public class MapResponse {
+
+    @Schema(description = "현재 사용자 위도", example = "37.5665")
     private Double currentLat;
+
+    @Schema(description = "현재 사용자 경도", example = "126.9780")
     private Double currentLng;
+
+    @Schema(description = "주변 매장 마커 목록")
     private List<MapMarkerResponse> markers;
+
+    @Schema(description = "선택한 매장 카드 정보, 선택한 매장이 없으면 null")
     private MapSelectedCardResponse selectedCard;
 }

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapSelectedCardResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapSelectedCardResponse.java
@@ -1,0 +1,22 @@
+package com.benepicker.map.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MapSelectedCardResponse {
+    private Long storeId;
+    private String storeName;
+    private String brandName;
+    private String storeAddress;
+    private String storeImageUrl;
+    private String storeLogoUrl;
+    private String storeAppLink;
+    private Double distanceKm;
+    private Integer viewCount;
+    private Boolean wished;
+    private List<MapBenefitResponse> benefits;
+}

--- a/backend/src/main/java/com/benepicker/map/dto/response/MapSelectedCardResponse.java
+++ b/backend/src/main/java/com/benepicker/map/dto/response/MapSelectedCardResponse.java
@@ -2,21 +2,45 @@ package com.benepicker.map.dto.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "선택한 매장 카드 상세 정보")
 public class MapSelectedCardResponse {
+
+    @Schema(description = "매장 ID", example = "1")
     private Long storeId;
+
+    @Schema(description = "매장명", example = "스타벅스 강남점")
     private String storeName;
+
+    @Schema(description = "브랜드명", example = "스타벅스")
     private String brandName;
+
+    @Schema(description = "매장 주소", example = "서울특별시 강남구 테헤란로 00")
     private String storeAddress;
+
+    @Schema(description = "매장 대표 이미지 URL", example = "https://example.com/store.png")
     private String storeImageUrl;
+
+    @Schema(description = "매장 로고 이미지 URL", example = "https://example.com/logo.png")
     private String storeLogoUrl;
+
+    @Schema(description = "매장 앱/외부 링크", example = "https://example.com/app")
     private String storeAppLink;
+
+    @Schema(description = "현재 위치로부터 거리(km)", example = "0.42")
     private Double distanceKm;
+
+    @Schema(description = "매장 조회수", example = "123")
     private Integer viewCount;
+
+    @Schema(description = "사용자의 찜 여부", example = "true")
     private Boolean wished;
+
+    @Schema(description = "매장 혜택 목록")
     private List<MapBenefitResponse> benefits;
 }

--- a/backend/src/main/java/com/benepicker/map/mapper/MapMapper.java
+++ b/backend/src/main/java/com/benepicker/map/mapper/MapMapper.java
@@ -1,0 +1,32 @@
+package com.benepicker.map.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.benepicker.map.dto.response.MapBenefitResponse;
+import com.benepicker.map.dto.response.MapMarkerResponse;
+import com.benepicker.map.dto.response.MapSelectedCardResponse;
+
+@Mapper
+public interface MapMapper {
+
+    List<MapMarkerResponse> findNearbyStores(
+            @Param("memberNo") Long memberNo,
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("radiusKm") double radiusKm
+    );
+
+    MapSelectedCardResponse findSelectedStoreCard(
+            @Param("memberNo") Long memberNo,
+            @Param("storeId") Long storeId,
+            @Param("lat") double lat,
+            @Param("lng") double lng
+    );
+
+    List<MapBenefitResponse> findStoreBenefits(@Param("storeId") Long storeId);
+
+    void increaseViewCount(@Param("storeId") Long storeId);
+}

--- a/backend/src/main/java/com/benepicker/map/service/MapService.java
+++ b/backend/src/main/java/com/benepicker/map/service/MapService.java
@@ -1,0 +1,7 @@
+package com.benepicker.map.service;
+
+import com.benepicker.map.dto.response.MapResponse;
+
+public interface MapService {
+    MapResponse getMapData(Long memberNo, double lat, double lng, double radiusKm, Long selectedStoreId);
+}

--- a/backend/src/main/java/com/benepicker/map/service/MapServiceImpl.java
+++ b/backend/src/main/java/com/benepicker/map/service/MapServiceImpl.java
@@ -1,0 +1,48 @@
+package com.benepicker.map.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.benepicker.map.dto.response.MapBenefitResponse;
+import com.benepicker.map.dto.response.MapMarkerResponse;
+import com.benepicker.map.dto.response.MapResponse;
+import com.benepicker.map.dto.response.MapSelectedCardResponse;
+import com.benepicker.map.mapper.MapMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MapServiceImpl implements MapService {
+
+    private final MapMapper mapMapper;
+
+    @Override
+    @Transactional
+    public MapResponse getMapData(Long memberNo, double lat, double lng, double radiusKm, Long selectedStoreId) {
+        List<MapMarkerResponse> markers = mapMapper.findNearbyStores(memberNo, lat, lng, radiusKm);
+
+        MapSelectedCardResponse selectedCard = null;
+
+        if (selectedStoreId != null) {
+            mapMapper.increaseViewCount(selectedStoreId);
+
+            selectedCard = mapMapper.findSelectedStoreCard(memberNo, selectedStoreId, lat, lng);
+
+            if (selectedCard != null) {
+                List<MapBenefitResponse> benefits = mapMapper.findStoreBenefits(selectedStoreId);
+                selectedCard.setBenefits(benefits);
+            }
+        }
+
+        return MapResponse.builder()
+                .currentLat(lat)
+                .currentLng(lng)
+                .markers(markers)
+                .selectedCard(selectedCard)
+                .build();
+    }
+}

--- a/backend/src/main/resources/mappers/map-mapper.xml
+++ b/backend/src/main/resources/mappers/map-mapper.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.benepicker.map.mapper.MapMapper">
+
+    <select id="findNearbyStores" resultType="com.benepicker.map.dto.response.MapMarkerResponse">
+        SELECT
+        s.store_id AS storeId,
+        s.store_name AS storeName,
+        b.brand_name AS brandName,
+        CAST(s.store_lat AS DOUBLE PRECISION) AS storeLat,
+        CAST(s.store_lng AS DOUBLE PRECISION) AS storeLng,
+        s.store_logo_url AS storeLogoUrl,
+        bf.benefit_type AS benefitType,
+        bf.benefit_content AS benefitSummary,
+        CAST(ROUND(CAST(
+        6371 * ACOS(
+        COS(RADIANS(#{lat}))
+        * COS(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        * COS(RADIANS(CAST(s.store_lng AS DOUBLE PRECISION)) - RADIANS(#{lng}))
+        + SIN(RADIANS(#{lat}))
+        * SIN(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        )
+        AS NUMERIC), 2) AS DOUBLE PRECISION) AS distanceKm,
+        CASE
+        WHEN w.wish_id IS NOT NULL THEN TRUE
+        ELSE FALSE
+        END AS wished
+        FROM store s
+        LEFT JOIN brand b
+        ON s.brand_id = b.brand_id
+        LEFT JOIN LATERAL (
+        SELECT
+        bf1.benefit_type,
+        bf1.benefit_content
+        FROM benefit bf1
+        WHERE bf1.store_id = s.store_id
+        AND (
+        (bf1.start_date IS NULL OR bf1.start_date &lt;= CURRENT_DATE)
+        AND (bf1.end_date IS NULL OR bf1.end_date &gt;= CURRENT_DATE)
+        )
+        ORDER BY bf1.created_date DESC
+        LIMIT 1
+        ) bf ON TRUE
+        LEFT JOIN wish w
+        ON w.store_id = s.store_id
+        AND w.member_no = #{memberNo}
+        AND w.wish_type = 'STORE'
+        WHERE s.store_lat IS NOT NULL
+        AND s.store_lng IS NOT NULL
+        AND (
+        6371 * ACOS(
+        COS(RADIANS(#{lat}))
+        * COS(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        * COS(RADIANS(CAST(s.store_lng AS DOUBLE PRECISION)) - RADIANS(#{lng}))
+        + SIN(RADIANS(#{lat}))
+        * SIN(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        )
+        ) &lt;= #{radiusKm}
+        ORDER BY distanceKm ASC
+    </select>
+
+    <select id="findSelectedStoreCard" resultType="com.benepicker.map.dto.response.MapSelectedCardResponse">
+        SELECT
+        s.store_id AS storeId,
+        s.store_name AS storeName,
+        b.brand_name AS brandName,
+        s.store_address AS storeAddress,
+        s.store_image_url AS storeImageUrl,
+        s.store_logo_url AS storeLogoUrl,
+        s.store_app_link AS storeAppLink,
+        CAST(ROUND(CAST(
+        6371 * ACOS(
+        COS(RADIANS(#{lat}))
+        * COS(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        * COS(RADIANS(CAST(s.store_lng AS DOUBLE PRECISION)) - RADIANS(#{lng}))
+        + SIN(RADIANS(#{lat}))
+        * SIN(RADIANS(CAST(s.store_lat AS DOUBLE PRECISION)))
+        )
+        AS NUMERIC), 2) AS DOUBLE PRECISION) AS distanceKm,
+        s.view_count AS viewCount,
+        CASE
+        WHEN w.wish_id IS NOT NULL THEN TRUE
+        ELSE FALSE
+        END AS wished
+        FROM store s
+        LEFT JOIN brand b
+        ON s.brand_id = b.brand_id
+        LEFT JOIN wish w
+        ON w.store_id = s.store_id
+        AND w.member_no = #{memberNo}
+        AND w.wish_type = 'STORE'
+        WHERE s.store_id = #{storeId}
+    </select>
+
+    <select id="findStoreBenefits" resultType="com.benepicker.map.dto.response.MapBenefitResponse">
+        SELECT
+        benefit_id AS benefitId,
+        benefit_type AS benefitType,
+        benefit_content AS benefitContent,
+        benefit_discount AS benefitDiscount,
+        benefit_condition AS benefitCondition,
+        start_date AS startDate,
+        end_date AS endDate
+        FROM benefit
+        WHERE store_id = #{storeId}
+        AND (
+        (start_date IS NULL OR start_date &lt;= CURRENT_DATE)
+        AND (end_date IS NULL OR end_date >= CURRENT_DATE)
+        )
+        ORDER BY created_date DESC
+    </select>
+
+    <update id="increaseViewCount">
+        UPDATE store
+        SET view_count = view_count + 1
+        WHERE store_id = #{storeId}
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 📝 작업 내용

* 지도 화면 기능 구현 (현재 위치 기반 매장 조회 + 선택 카드)
* Swagger 명세 추가 및 API 문서화

---

## 🔗 관련 이슈

Closes #24 

---

## 🔧 상세 변경 사항

* [x] `/api/map` API 구현 (현재 위치 기반 주변 매장 조회)
* [x] 매장 마커 + 선택 카드 통합 응답 구조 설계
* [x] Haversine 공식 기반 거리 계산 로직 적용
* [x] DTO 구조 설계 (MapResponse, MapMarkerResponse, MapSelectedCardResponse 등)
* [x] Swagger 문서화 (파라미터, 응답 예시 포함)

---

## 🧪 테스트

* [x] Swagger를 통한 API 호출 정상 동작 확인
* [x] 현재 위치 기준 반경 내 매장 조회 정상 동작 확인
* [x] selectedStoreId 포함/미포함 케이스 테스트
* [x] 찜 여부(wish) 정상 반영 확인
* [x] 거리(distanceKm) 계산 값 정상 출력 확인
* [x] 잘못된 파라미터 입력 시 에러 응답 확인

---

## 📸 스크린샷 (optional)

<!-- Swagger 실행 결과 / 지도 화면 캡처 첨부 -->
<img width="606" height="441" alt="image" src="https://github.com/user-attachments/assets/29e76638-2c6d-418a-865c-674c49a0dea7" />

<img width="562" height="347" alt="image" src="https://github.com/user-attachments/assets/433bd915-1db9-43bd-bdec-5b9769139fd7" />


---

## 💬 참고 사항

* 현재는 `@RequestParam` 방식으로 구현되어 있으며, 향후 필터(브랜드, 혜택 타입 등) 확장 시 `MapStoreSearchRequest` DTO로 리팩토링 예정
* 거리 계산은 SQL 기반으로 수행되며, 데이터 증가 시 성능 개선 필요 (Bounding Box 또는 PostGIS 고려)
* 대표 혜택은 최신(created_date 기준) 1건으로 설정되어 있으며, 추후 기획에 따라 우선순위 로직 변경 가능
