### PR TITLE
API 연동 - 배포 서버 baseURL 적용 및 gitignore 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,14 @@ backend/build/
 backend/out/
 backend/*.class
 backend/src/main/resources/config.properties
+backend/.env
+backend/bin/
+
+# ============================================================
+# Tools / Local workspace
+# ============================================================
+.claude/
+.metadata/
 
 # ============================================================
 # Frontend (Expo / React Native 모바일 앱)

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,13 +1,16 @@
 import apiClient from './client';
 
 export const login = (data) =>
-  apiClient.post('/member/login', data);
+  apiClient.post('/api/member/login', data);
 
 export const signup = (data) =>
-  apiClient.post('/member/signup', data);
+  apiClient.post('/api/member/signup', data);
 
 export const checkEmail = (memberEmail) =>
-  apiClient.get('/member/check-email', { params: { memberEmail } });
+  apiClient.get('/api/member/check-email', { params: { memberEmail } });
 
 export const checkNickname = (memberNickname) =>
-  apiClient.get('/member/check-nickname', { params: { memberNickname } });
+  apiClient.get('/api/member/check-nickname', { params: { memberNickname } });
+
+export const logout = () =>
+  apiClient.post('/api/auth/logout');

--- a/frontend/src/constants/config.js
+++ b/frontend/src/constants/config.js
@@ -1,5 +1,3 @@
-const API_BASE_URL = __DEV__
-  ? 'http://10.0.2.2:8080/api'   // Android 에뮬레이터 → localhost
-  : 'https://your-production-url.com/api'; // TODO: 운영 URL 교체
+const API_BASE_URL = 'http://54.253.35.160:8080';
 
 export default API_BASE_URL;


### PR DESCRIPTION
## Summary
- baseURL을 배포 서버 `http://54.253.35.160:8080`로 변경 (swagger 경로 구조에 맞춰 `/api` prefix 제거)
- `auth.js` 각 호출 경로에 `/api` 명시, `logout` 추가
- 루트 `.gitignore`에 `.claude/`, `.metadata/`, `backend/.env`, `backend/bin/` 추가

## Test plan
- [x] 배포 서버 `/api/member/login` 200 응답 확인 (test@example.com / 1234)
- [x] `/api/member/check-email` 200 응답 확인
- [ ] Expo 앱에서 로그인 → 홈 진입 확인