### PR TITLE
웹 Mixed Content 차단 우회: Vercel 프록시 rewrite

### DIFF
--- a/frontend/src/constants/config.js
+++ b/frontend/src/constants/config.js
@@ -1,3 +1,9 @@
-const API_BASE_URL = 'http://54.253.35.160:8080';
+import { Platform } from 'react-native';
+
+// 웹: same-origin으로 요청 → Vercel rewrite가 백엔드로 프록시 (Mixed Content/CORS 우회)
+// 네이티브: 백엔드 IP로 직접 요청
+const API_BASE_URL = Platform.OS === 'web'
+  ? '/proxy'
+  : 'http://54.253.35.160:8080';
 
 export default API_BASE_URL;

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "npm install",
   "framework": null,
   "rewrites": [
+    { "source": "/proxy/:path*", "destination": "http://54.253.35.160:8080/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
HTTPS(Vercel) → HTTP(백엔드) 직접 요청이 브라우저 Mixed Content 정책으로 차단되는 문제 해결.

- `vercel.json`: `/proxy/:path*` → `http://54.253.35.160:8080/:path*` rewrite 추가
- `src/constants/config.js`: 웹에서만 `baseURL`을 `/proxy`로 전환 (네이티브는 기존 IP 유지)

## 동작
브라우저는 same-origin HTTPS로 요청 → Vercel 서버가 서버-to-서버로 백엔드 포워딩 → Mixed Content/CORS 둘 다 회피.

## Test plan
- [ ] Vercel 배포 후 로그인/회원가입 흐름에서 CORS/Mixed Content 에러 없음
- [ ] 모바일 빌드 영향 없음 (baseURL 분기)