### PR TITLE
chore: 백엔드 API 엔드포인트 새 서버 IP로 교체

### DIFF
--- a/frontend/src/constants/config.js
+++ b/frontend/src/constants/config.js
@@ -4,6 +4,6 @@ import { Platform } from 'react-native';
 // 네이티브: 백엔드 IP로 직접 요청
 const API_BASE_URL = Platform.OS === 'web'
   ? '/proxy'
-  : 'http://54.253.35.160:8080';
+  : 'http://43.203.64.160:8080';
 
 export default API_BASE_URL;

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "npm install",
   "framework": null,
   "rewrites": [
-    { "source": "/proxy/:path*", "destination": "http://54.253.35.160:8080/:path*" },
+    { "source": "/proxy/:path*", "destination": "http://43.203.64.160:8080/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## 변경 사항

기존 백엔드 서버(`54.253.35.160`)에서 신규 EC2 인스턴스(`43.203.64.160`, Elastic IP)로 엔드포인트 전환.

### 수정 파일
- `frontend/vercel.json` — Vercel rewrite destination 교체
- `frontend/src/constants/config.js` — 네이티브 앱 API base URL 교체

### 배포 구조
- 웹(Vercel): `/proxy/*` → `http://43.203.64.160:8080/*`
- 네이티브: 직접 `http://43.203.64.160:8080`

### 신규 서버 상태
- Amazon Linux 2023, t3.micro
- Java 21 (Corretto), systemd 서비스 등록 완료 (재부팅 자동 복구)
- Elastic IP 고정 → IP 변경 리스크 없음
- 회원가입 통신사(memberCarrier) 필드 포함된 최신 코드 배포 완료