### PR TITLE
fix: CORS 허용 도메인에 Vercel 배포 주소 추가

### DIFF
--- a/backend/src/main/java/com/benepicker/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/benepicker/common/config/SecurityConfig.java
@@ -60,8 +60,12 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedOriginPatterns(List.of(
+                "http://localhost:5173",
+                "https://bene-picker.vercel.app",
+                "https://*.vercel.app"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 


### PR DESCRIPTION
## 문제
배포된 Vercel 페이지에서 회원가입 시 `403 (Forbidden)` + `Invalid CORS request` 응답.

## 원인
SecurityConfig 의 `allowedOrigins` 에 `http://localhost:5173` 만 있어서, 브라우저가 자동으로 붙이는 `Origin: https://bene-picker.vercel.app` 헤더가 Spring Security CORS 필터에 거부됨.

## 수정
- `setAllowedOrigins` → `setAllowedOriginPatterns` 로 변경 (와일드카드 + credentials=true 동시 사용 위해 필요)
- 허용 도메인: localhost:5173, bene-picker.vercel.app, \*.vercel.app (preview 배포)
- PATCH 메서드 추가 (`/me/profile`, `/me/password`, `/me/privacy` 가 PATCH 사용)

## 테스트
머지 후 EC2 재배포 → Vercel 회원가입 동작 확인