### PR TITLE
feat: 마이페이지에 로그아웃 버튼 추가

### DIFF
--- a/frontend/src/screens/mypage/MyPageScreen.jsx
+++ b/frontend/src/screens/mypage/MyPageScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import {
   View, Text, StyleSheet, ScrollView, Image, TouchableOpacity, useWindowDimensions,
-  TextInput, Alert, ActivityIndicator,
+  TextInput, Alert, ActivityIndicator, Platform,
 } from 'react-native';
 
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -9,7 +9,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
 import { useAuth } from '../../context/AuthContext';
-import { checkNickname, updateProfile } from '../../api/auth';
+import { checkNickname, updateProfile, logout } from '../../api/auth';
 
 const BANKS = [
   { id: 'won',    label: 'WON',   color: '#2B6EEB', bg: '#FFFFFF', logo: require('../../../assets/logo/won_logo.png') },
@@ -22,7 +22,7 @@ const MENU = ['나의 리뷰 관리', '고객센터', '1:1 문의'];
 
 export default function MyPageScreen() {
   const navigation = useNavigation();
-  const { user, refreshUser, updateLocalProfileImage } = useAuth();
+  const { user, refreshUser, updateLocalProfileImage, signOut } = useAuth();
   const [selected, setSelected] = useState('won');
 
   const { width: winWidth } = useWindowDimensions();
@@ -79,6 +79,29 @@ export default function MyPageScreen() {
     } finally {
       setNickSaving(false);
     }
+  };
+
+  const doLogout = async () => {
+    try {
+      await logout();
+    } catch (_) {
+      // 서버 응답이 실패해도 로컬 토큰은 제거한다
+    } finally {
+      await signOut();
+    }
+  };
+
+  const handleLogout = () => {
+    if (Platform.OS === 'web') {
+      if (window.confirm('정말 로그아웃 하시겠어요?')) {
+        doLogout();
+      }
+      return;
+    }
+    Alert.alert('로그아웃', '정말 로그아웃 하시겠어요?', [
+      { text: '취소', style: 'cancel' },
+      { text: '로그아웃', style: 'destructive', onPress: doLogout },
+    ]);
   };
 
   const pickProfileImage = async () => {
@@ -214,6 +237,13 @@ export default function MyPageScreen() {
               <Ionicons name="chevron-forward" size={18} color="#7C3AED" />
             </TouchableOpacity>
           ))}
+          <TouchableOpacity
+            style={[styles.menuRow, styles.menuDivider]}
+            onPress={handleLogout}
+          >
+            <Text style={[styles.menuText, styles.logoutText]}>로그아웃</Text>
+            <Ionicons name="log-out-outline" size={18} color="#EF4444" />
+          </TouchableOpacity>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -339,4 +369,5 @@ const styles = StyleSheet.create({
     borderTopColor: '#E5E7EB',
   },
   menuText: { fontSize: 14, fontWeight: '600', color: '#111827' },
+  logoutText: { color: '#EF4444' },
 });


### PR DESCRIPTION
## 변경 사항
마이페이지 메뉴 하단에 로그아웃 항목 추가.

### 동작
1. 로그아웃 항목 탭 → 확인 다이얼로그 (네이티브는 Alert, 웹은 window.confirm)
2. 서버 `POST /api/auth/logout` 호출 (실패해도 무시 — JWT stateless라 서버 상태 없음)
3. AuthContext.signOut() → AsyncStorage 의 accessToken/refreshToken/profileImageLocalUri 제거
4. token=null 되면 App.jsx 가 자동으로 AuthNavigator(로그인 화면) 로 전환

### 수정 파일
- `frontend/src/screens/mypage/MyPageScreen.jsx`

### 기존에 이미 있던 것 (재사용)
- 백엔드 `POST /api/auth/logout` (no-op, 200)
- `frontend/src/api/auth.js` 의 `logout()` 함수
- `AuthContext.signOut()`

### 디자인
- 기존 메뉴(고객센터 등) 하단에 구분선으로 추가
- 텍스트 빨강(#EF4444), 로그아웃 아이콘 표시로 파괴적 액션임을 시각적으로 구분