### PR TITLE
지도 상세 카드: benefits 비어있을 때 로컬 데이터 유지

### DIFF
--- a/frontend/src/screens/map/MapScreen.jsx
+++ b/frontend/src/screens/map/MapScreen.jsx
@@ -190,7 +190,7 @@ export default function MapScreen() {
         ],
       });
     }
-    // 백엔드에서 상세 카드 있으면 덮어쓰기 (실패 시 그대로 유지)
+    // 백엔드가 selectedCard를 주더라도 benefits가 비어 있으면 로컬 데이터 유지
     try {
       const res = await getMapData({
         lat: INHA_LAT,
@@ -198,7 +198,10 @@ export default function MapScreen() {
         radiusKm: 1,
         selectedStoreId: storeId,
       });
-      if (res.data?.selectedCard) setSelectedCard(res.data.selectedCard);
+      const sc = res.data?.selectedCard;
+      if (sc && Array.isArray(sc.benefits) && sc.benefits.length > 0) {
+        setSelectedCard(sc);
+      }
     } catch {}
   };
 

--- a/frontend/src/screens/map/MapScreen.web.jsx
+++ b/frontend/src/screens/map/MapScreen.web.jsx
@@ -338,7 +338,11 @@ export default function MapScreen() {
     }
     try {
       const res = await getMapData({ lat: INHA_LAT, lng: INHA_LNG, radiusKm: 1, selectedStoreId: storeId });
-      if (res.data?.selectedCard) setSelectedCard(res.data.selectedCard);
+      const sc = res.data?.selectedCard;
+      // 백엔드가 selectedCard를 주더라도 benefits가 비어 있으면 로컬 데이터 유지
+      if (sc && Array.isArray(sc.benefits) && sc.benefits.length > 0) {
+        setSelectedCard(sc);
+      }
     } catch {}
   };
 


### PR DESCRIPTION
## Summary
마커 클릭 시 백엔드가 `selectedCard`를 반환하지만 `benefits`가 빈 배열이면, 이미 설정한 로컬 mock 혜택 데이터가 덮어쓰여져 빈 카드로 보이는 문제 수정.

- `MapScreen.jsx` / `MapScreen.web.jsx` 둘 다 동일한 방어 로직 추가
- `sc.benefits` 가 비어있지 않을 때만 setSelectedCard 호출

## Test plan
- [ ] 마커 클릭 시 바텀 시트에 혜택이 비어있지 않은지
- [ ] 백엔드가 benefits 채워서 주면 그 값이 우선 반영되는지