### PR TITLE
웹 지도: 확대/축소 레벨 제한

### DIFF
--- a/frontend/src/screens/map/MapScreen.web.jsx
+++ b/frontend/src/screens/map/MapScreen.web.jsx
@@ -188,6 +188,10 @@ export default function MapScreen() {
           center: new kakao.maps.LatLng(INHA_LAT, INHA_LNG),
           level: 3,
         });
+        // 과도한 확대로 Kakao POI 라벨이 거대해지는 것 방지
+        // (Kakao 줌 레벨은 역순: 숫자 작을수록 확대. 3을 최소값으로)
+        map.setMinLevel(3);
+        map.setMaxLevel(8);
         mapRef.current = map;
 
         // 현재 위치 점


### PR DESCRIPTION
Kakao 지도 자체 POI 라벨이 과도한 확대 시 거대하게 표시되는 문제. Kakao API에 POI 라벨 숨김 옵션이 없어서 setMinLevel(3)/setMaxLevel(8)로 줌 범위를 제한.