### PR TITLE
백엔드 EC2 자동 배포 파이프라인 추가

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,62 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+
+      - name: Install Gradle
+        run: |
+          GRADLE_VERSION=8.10.2
+          curl -fsSL -o /tmp/gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
+          sudo unzip -q /tmp/gradle.zip -d /opt
+          echo "/opt/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+
+      - name: Build JAR
+        working-directory: backend
+        run: gradle clean bootJar --no-daemon -x test
+
+      - name: Configure SSH
+        env:
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$EC2_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$EC2_HOST" >> ~/.ssh/known_hosts
+
+      - name: Upload JAR
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar \
+            "ec2-user@$EC2_HOST:/home/ec2-user/BenePicker/backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar"
+
+      - name: Restart service
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          ssh -i ~/.ssh/deploy_key "ec2-user@$EC2_HOST" \
+            'sudo systemctl restart benepicker && sleep 3 && sudo systemctl is-active benepicker'

--- a/deploy/benepicker.service
+++ b/deploy/benepicker.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=BenePicker Spring Boot Backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ec2-user
+Group=ec2-user
+WorkingDirectory=/home/ec2-user/BenePicker/backend
+EnvironmentFile=/etc/benepicker/backend.env
+ExecStart=/usr/bin/java -Xms256m -Xmx512m -jar /home/ec2-user/BenePicker/backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar
+SuccessExitStatus=143
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=benepicker
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## 개요
main 브랜치의 `backend/**` 변경 푸시 시 백엔드 JAR을 자동으로 EC2에 배포하는 파이프라인 추가.

## 추가 파일
- `.github/workflows/deploy-backend.yml`
  - 트리거: `main` 브랜치 push 중 `backend/**` 경로 변경
  - 빌드: JDK 21 (Corretto) + Gradle 8.10.2로 `bootJar` (테스트 제외)
  - 전송: `scp`로 EC2 `~/BenePicker/backend/build/libs/`에 jar 업로드
  - 재시작: `sudo systemctl restart benepicker` + 상태 확인
- `deploy/benepicker.service`
  - systemd 유닛 파일 (Type=simple, Restart=on-failure)
  - `EnvironmentFile=/etc/benepicker/backend.env`에서 DB/JWT 설정 로드

## 머지 전후 필요한 일회성 설정
### 1) GitHub Secrets
- `EC2_HOST` = 43.203.64.160
- `EC2_SSH_KEY` = pem 전체 내용

### 2) EC2 초기 세팅 (EC2 Instance Connect)
- `/etc/benepicker/backend.env` 생성 (mode 600, owner=ec2-user, **로테이트된 값**)
- 기존 raw `java -jar` 프로세스 kill
- `sudo cp deploy/benepicker.service /etc/systemd/system/` + `daemon-reload` + `enable --now`

## 동작 확인 계획
- 최초 머지 직후: `backend/**` 변경 없어서 워크플로우 미실행 (의도)
- 설정 완료 후 `backend/` 아무 파일 커밋 → main 푸시 → Actions 초록불 확인