### PR TITLE
배포 파이프라인 jar 파일명·서비스 설정 수정

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -51,8 +51,8 @@ jobs:
           EC2_HOST: ${{ secrets.EC2_HOST }}
         run: |
           scp -i ~/.ssh/deploy_key \
-            backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar \
-            "ec2-user@$EC2_HOST:/home/ec2-user/BenePicker/backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar"
+            backend/build/libs/backend-0.0.1-SNAPSHOT.jar \
+            "ec2-user@$EC2_HOST:/home/ec2-user/BenePicker/backend/build/libs/backend-0.0.1-SNAPSHOT.jar"
 
       - name: Restart service
         env:

--- a/deploy/benepicker.service
+++ b/deploy/benepicker.service
@@ -1,21 +1,17 @@
 [Unit]
 Description=BenePicker Spring Boot Backend
-After=network-online.target
-Wants=network-online.target
+After=network.target
 
 [Service]
 Type=simple
 User=ec2-user
-Group=ec2-user
 WorkingDirectory=/home/ec2-user/BenePicker/backend
-EnvironmentFile=/etc/benepicker/backend.env
-ExecStart=/usr/bin/java -Xms256m -Xmx512m -jar /home/ec2-user/BenePicker/backend/build/libs/BenePicker-0.0.1-SNAPSHOT.jar
+ExecStart=/usr/lib/jvm/java-21-amazon-corretto/bin/java -Xms256m -Xmx512m -jar build/libs/backend-0.0.1-SNAPSHOT.jar
 SuccessExitStatus=143
-Restart=on-failure
-RestartSec=5
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=benepicker
+Restart=always
+RestartSec=10
+StandardOutput=append:/home/ec2-user/BenePicker/backend/app.log
+StandardError=append:/home/ec2-user/BenePicker/backend/app.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## 문제
PR #58로 추가한 백엔드 자동 배포 파이프라인에 실제 EC2 운영 환경과 맞지 않는 두 부분이 있음.

## 수정 1: CI 워크플로우 jar 파일명
- 빌드된 실제 파일: `backend-0.0.1-SNAPSHOT.jar` (`settings.gradle`의 `rootProject.name = 'backend'`)
- PR #58에서 `BenePicker-0.0.1-SNAPSHOT.jar`로 잘못 적혀 있어서 scp 단계에서 `No such file` 으로 실패할 상태였음

## 수정 2: systemd 유닛 파일
- 원래 유닛 파일은 `EnvironmentFile=/etc/benepicker/backend.env`에서 env를 읽도록 되어 있었음
- 그러나 실제 앱은 `io.github.cdimascio:dotenv-java:3.0.0` 라이브러리로 `backend/.env` (작업 디렉토리) 를 직접 읽음
- → EnvironmentFile 지시문 제거, 기타 항목(ExecStart 자바 절대 경로, 로그 append 출력 등)을 EC2에서 실제 동작 중인 설정과 일치시킴

## 배포 흐름
`main` → `backend/**` push → Actions 빌드 (`backend-0.0.1-SNAPSHOT.jar`) → scp → `sudo systemctl restart benepicker` → 3초 후 active 확인