### PR TITLE
웹 지도: 바텀시트가 Kakao POI overlay에 가려지는 문제 수정

### DIFF
--- a/frontend/src/screens/map/MapScreen.web.jsx
+++ b/frontend/src/screens/map/MapScreen.web.jsx
@@ -342,7 +342,7 @@ export default function MapScreen() {
     <View style={styles.container}>
       <div
         ref={containerRef}
-        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', zIndex: 1 }}
       />
 
       <SafeAreaView edges={['top']} style={styles.headerSafe} pointerEvents="box-none">
@@ -434,6 +434,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     overflow: 'hidden',
     boxShadow: '0 4px 10px rgba(0,0,0,0.15)',
+    zIndex: 10,
   },
   sheetImage: { width: 130, height: '100%' },
   sheetBody: { flex: 1, padding: 12, justifyContent: 'space-between' },


### PR DESCRIPTION
## 문제
웹 지도에서 스타벅스·CU처럼 **Kakao 지도가 자체 POI로 인식하는 유명 브랜드** 핀 클릭 시:
- 핀 클릭으로 바텀시트 상태(`selectedCard`)는 정상 설정됨
- 그러나 같은 클릭이 Kakao 내부에도 전파되어 Kakao의 기본 POI 오버레이가 상위 z-index로 뜸 → 우리 바텀시트가 가려져서 안 보임
- 확대/축소 조작 시 Kakao POI 오버레이가 잠깐 사라지는 순간에만 바텀시트가 노출되는 기이 현상

## 수정
`MapScreen.web.jsx` 두 곳 z-index 조정:
- 지도 컨테이너 `<div>`: `zIndex: 1` → Kakao 내부 요소들을 자체 stacking context로 가둠
- 바텀시트 스타일(`styles.sheet`): `zIndex: 10` → 어떤 Kakao overlay보다도 위에 뜨도록

## 영향 범위
- 웹 빌드에만 영향 (`MapScreen.web.jsx`만 수정)
- 네이티브(`MapScreen.jsx`)는 WebView 내 HTML 기반이라 무관