### PR TITLE
AuthContext 토큰 만료 처리 + README 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,160 +1,294 @@
-# 🌿 BenePicker
+# BenePicker
 
-> 나에게 맞는 복지 혜택을 찾아주는 모바일 서비스
+> 내 위치 주변의 통신사·카드·멤버십 혜택을 한눈에 보여주는 풀스택 앱
 
 ---
 
-## 📁 프로젝트 구조
+## 구성
+
+BenePicker는 Spring Boot 백엔드 + React Native(Expo) 모바일·웹 프론트로 이루어진 모노레포입니다. 웹은 Expo의 React Native Web 타겟을 Vercel에 빌드·배포하고, 백엔드는 EC2(Amazon Linux 2023)에 systemd로 상주합니다. `main` 브랜치에 머지되는 순간 프론트(Vercel)와 백엔드(GitHub Actions → EC2)가 자동 배포됩니다.
 
 ```
 BenePicker/
-├── backend/     # Spring Boot API 서버
-└── frontend/    # React Native Expo 모바일 앱
+├── backend/                  Spring Boot REST API + WebSocket
+├── frontend/                 Expo 앱 (iOS / Android / Web)
+├── deploy/benepicker.service systemd 유닛 (EC2 배포용 레퍼런스)
+└── .github/workflows/        GitHub Actions (백엔드 자동 배포)
 ```
 
 ---
 
-## 🛠 기술 스택
+## 기술 스택
+
+### Backend (`/backend`)
+| 항목 | 값 |
+|---|---|
+| Language | Java 21 (Amazon Corretto) |
+| Framework | Spring Boot 3.5.8 |
+| DB | PostgreSQL (Supabase, HikariCP) |
+| Persistence | MyBatis 3.0.5 (`mapUnderscoreToCamelCase`) |
+| Auth | Spring Security + JWT (stateless, BCrypt) |
+| Real-time | WebSocket (STOMP/SockJS `/ws`, 네이티브용 순수 WS `/ws-native`) |
+| Mail | Spring Boot Starter Mail |
+| Config | `dotenv-java` 로 `backend/.env` 로드 → System Property 주입 |
+| Docs | Springdoc OpenAPI (Swagger UI `/swagger-ui.html`) |
+
+### Frontend (`/frontend`)
+| 항목 | 값 |
+|---|---|
+| Framework | React Native + Expo SDK 55 |
+| Language | JavaScript (JSX) |
+| 타겟 | iOS / Android / Web (React Native Web 0.21) |
+| Navigation | React Navigation v7 (bottom-tabs + native-stack) |
+| HTTP | Axios (interceptor 기반 토큰 주입·401 처리) |
+| State | Context API (`AuthContext`) |
+| 저장소 | AsyncStorage (accessToken / refreshToken / 프로필 이미지 로컬 URI) |
+| 지도 | Kakao Maps SDK (웹: 직접 로드 / 네이티브: WebView + HTML 브릿지) |
+
+---
+
+## 배포 구성
+
+### 프론트엔드 (Vercel)
+- `main` 푸시 시 Vercel이 자동 감지 → `npx expo export --platform web` → 정적 배포
+- 루트 디렉토리: `frontend/`
+- `vercel.json`의 rewrite로 `/proxy/*` 요청을 EC2 백엔드(`http://43.203.64.160:8080`)로 프록시 (Mixed Content / CORS 우회)
+
+### 백엔드 (EC2 + GitHub Actions)
+- 트리거: `main` 브랜치에 `backend/**` 변경 푸시
+- 흐름:
+  1. GitHub Actions runner가 JDK 21 + Gradle 8.10.2 설치
+  2. `gradle clean bootJar -x test` → `backend/build/libs/backend-0.0.1-SNAPSHOT.jar` 생성
+  3. `scp`로 EC2 `/home/ec2-user/BenePicker/backend/build/libs/`에 업로드
+  4. `ssh ec2-user@... 'sudo systemctl restart benepicker'` → 3초 뒤 `is-active` 검증
+- 서비스: systemd `benepicker.service` 가 상주, 프로세스 다운 시 자동 재시작
+
+### 필요한 GitHub Secrets
+| Secret | 값 |
+|---|---|
+| `EC2_HOST` | EC2 public IP |
+| `EC2_SSH_KEY` | 인스턴스 키페어 pem 파일 전체 내용 |
+
+### EC2 쪽 선행 세팅 (최초 1회)
+1. `~/BenePicker/backend/.env` 작성 (아래 *환경변수* 참고, mode 600)
+2. `~/.ssh/authorized_keys`에 `EC2_SSH_KEY`의 공개키 등록
+3. `deploy/benepicker.service`를 `/etc/systemd/system/`에 복사 → `sudo systemctl daemon-reload && sudo systemctl enable --now benepicker`
+
+---
+
+## API 엔드포인트
+
+> 인증이 필요한 엔드포인트는 `Authorization: Bearer <accessToken>` 헤더 필수. 로그인·회원가입·이메일 인증·WebSocket 핸드셰이크·Swagger는 인증 없이 접근.
+
+| Method | Path | 설명 |
+|---|---|---|
+| POST | `/api/member/login` | 로그인 (이메일/비번 → access·refresh 토큰) |
+| POST | `/api/member/signup` | 회원가입 |
+| GET | `/api/member/check-email` | 이메일 중복 확인 |
+| GET | `/api/member/check-nickname` | 닉네임 중복 확인 |
+| GET | `/api/member/me` | 내 정보 조회 |
+| PATCH | `/api/member/me/profile` | 프로필 수정 |
+| PATCH | `/api/member/me/password` | 비밀번호 변경 |
+| PATCH | `/api/member/me/privacy` | 개인정보 동의 변경 |
+| POST | `/api/auth/logout` | 로그아웃 |
+| GET | `/api/home/benefits/nearby` | 홈: 내 주변 혜택 목록 |
+| GET | `/api/map` | 지도: 마커·매장·혜택 통합 응답 |
+| GET | `/benefits/{benefitId}` | 혜택 상세 |
+| GET | `/search` | 검색 |
+| GET | `/search/history` | 최근 검색어 |
+| DELETE | `/search/history/{searchId}` | 최근 검색어 개별 삭제 |
+| DELETE | `/search/history` | 최근 검색어 전체 삭제 |
+| POST | `/wishes/stores/{storeId}` | 매장 찜 |
+| DELETE | `/wishes/stores/{storeId}` | 매장 찜 해제 |
+| POST | `/wishes/brands/{brandId}` | 브랜드 찜 |
+| DELETE | `/wishes/brands/{brandId}` | 브랜드 찜 해제 |
+
+API 응답은 `ApiResponse<T>` 공통 래퍼로 `{ code, message, data }` 형태.
+
+---
+
+## 프로젝트 레이아웃
 
 ### Backend
-| 항목 | 기술 |
-|---|---|
-| Language | Java 21 |
-| Framework | Spring Boot 3.5 |
-| Security | Spring Security + JWT |
-| DB | Oracle + MyBatis |
-| 기타 | Spring Mail, WebSocket (STOMP) |
-
-### Frontend (Mobile)
-| 항목 | 기술 |
-|---|---|
-| Framework | React Native (Expo SDK 55) |
-| Language | TypeScript |
-| 상태관리 | Context API |
-| HTTP | Axios |
-| 저장소 | AsyncStorage |
-| 네비게이션 | React Navigation v7 |
-
----
-
-## 🌿 브랜치 전략
-
 ```
-main
-└── develop          ← PR 통합 브랜치
-    ├── backend      ← 백엔드 개발 (백엔드 + 풀스택)
-    └── frontend     ← 프론트 개발 (프론트 + 풀스택)
+backend/src/main/java/com/benepicker/
+├── BenePickerApplication.java
+├── common/
+│   ├── auth/                JWT 인증 관련 Principal / UserDetails
+│   ├── config/              Security / DB / WebSocket / Swagger / Env(Dotenv)
+│   ├── exception/           전역 예외 핸들러
+│   └── util/                JwtUtil, JwtFilter, Utility
+├── auth/                    로그아웃
+├── member/                  회원 CRUD / 로그인 / 프로필
+├── home/                    홈 화면 데이터
+├── map/                     지도 마커 / 매장 상세
+├── benefit/                 혜택 상세
+├── search/                  검색 / 최근 검색어
+└── wish/                    매장·브랜드 찜
 ```
+각 도메인은 `controller` → `service` / `service.impl` → `mapper` 의 3계층 구조. MyBatis XML은 `src/main/resources/mappers/<domain>-mapper.xml`.
 
-| 브랜치 | 용도 | 작업자 |
-|---|---|---|
-| `main` | 최종 배포 — 직접 작업 금지 | - |
-| `develop` | 작업물 통합 — PR 대상 | - |
-| `backend` | 백엔드 기능 개발 | 백엔드, 풀스택 |
-| `frontend` | 모바일 기능 개발 | 프론트, 풀스택 |
-
-### 작업 흐름
+### Frontend
 ```
-backend  ──PR──▶ develop ──PR──▶ main
-frontend ──PR──▶ develop ──PR──▶ main
-```
-
-### PR 규칙
-- `develop` 머지 : 본인 제외 **1명 이상** 리뷰 & 승인 후 머지
-- `main` 머지 : **전원 확인** 후 머지
-- 본인이 올린 PR은 **본인이 직접 머지 금지**
-- push 전 반드시 **pull 먼저** 받기
-
----
-
-## 📝 Git 커밋 태그 규칙
-
-| 태그 | 의미 | 예시 |
-|---|---|---|
-| `[Add]` | 새로운 기능 또는 파일 추가 | `[Add] 회원가입 API 추가` |
-| `[Delete]` | 기능 또는 파일 삭제 | `[Delete] 미사용 파일 제거` |
-| `[Update]` | 기능 수정 (로직 변경 포함) | `[Update] 로그인 유효성 검사 수정` |
-| `[Fix]` | 버그 수정 | `[Fix] 토큰 만료 오류 수정` |
-| `[Chore]` | 기타 작업 (주석, 설정 변경 등) | `[Chore] application.properties 수정` |
-
----
-
-## ✍️ 코딩 컨벤션
-
-### 메서드 네이밍
-
-| prefix | 의미 | 예시 |
-|---|---|---|
-| `add` | 등록 | `addMember()` |
-| `get` | 단건 조회 | `getMember()` |
-| `getList` | 목록 조회 | `getMemberList()` |
-| `update` | 수정 | `updateMember()` |
-| `delete` | 삭제 | `deleteMember()` |
-
-### 네이밍 케이스
-
-| 구분 | 방식 | 적용 대상 |
-|---|---|---|
-| `camelCase` | 변수명, 함수명 | `memberEmail`, `handleLogin()` |
-| `PascalCase` | 클래스, DTO, 컴포넌트 | `MemberController`, `LoginScreen` |
-| `UPPER_SNAKE_CASE` | 상수 | `API_BASE_URL` |
-
-### 주석 규칙
-
-**백엔드 (JavaDoc)**
-```java
-/**
- * dev. 이름
- * 기능 : 회원 정보 조회
- * @param memberNo 회원 번호
- * @return Member 회원 정보
- */
-public Member getMember(int memberNo) { ... }
-```
-
-**프론트 (JSDoc)**
-```typescript
-/**
- * dev. 이름
- * 기능 : 로그인 API 호출
- * @param data 이메일, 비밀번호
- * @returns accessToken, refreshToken
- */
-export const login = (data: LoginRequest) => apiClient.post(...)
+frontend/
+├── App.jsx                  AuthProvider + Navigation 컨테이너 (웹은 폰 프레임 UI)
+├── app.json                 Expo 설정 (패키지명, 아이콘, 권한)
+├── vercel.json              Vercel 빌드·rewrite 설정
+└── src/
+    ├── api/                 Axios 인스턴스 + 도메인별 API 모듈
+    ├── constants/           API base URL, Kakao 키
+    ├── context/             AuthContext (토큰 상태 + 프로필 이미지 로컬 캐시)
+    ├── navigation/          AuthNavigator / AppNavigator (5탭)
+    └── screens/
+        ├── auth/            로그인 / 회원가입
+        ├── home/            홈
+        ├── map/             지도 (네이티브: WebView / 웹: 직접 SDK)
+        ├── search/          검색
+        ├── history/         사용내역
+        ├── bookmark/        찜
+        └── mypage/          MY
 ```
 
 ---
 
-## ⚙️ 로컬 실행 방법
+## 로컬 실행
 
 ### Backend
 ```bash
 cd backend
 
-# config.properties 설정 (config.properties.example 참고)
-cp src/main/resources/config.properties.example src/main/resources/config.properties
-# config.properties에 DB / Mail / JWT 실제 값 입력 후
+# backend/.env 작성 (아래 환경변수 참고)
 
+# gradle wrapper 가 없는 경우 먼저 설치: gradle -v
 ./gradlew bootRun
-# 실행 주소: http://localhost:8080
+# 또는 gradle bootRun
+
+# http://localhost:8080
+# Swagger: http://localhost:8080/swagger-ui.html
 ```
 
-### Frontend (Mobile)
+### Frontend (모바일)
 ```bash
 cd frontend
 npm install
 
-npm run android   # Android 에뮬레이터
-npm run ios       # iOS (macOS 필요)
+npm run android        # Android 에뮬레이터
+npm run ios            # iOS (macOS 필요)
+npm start              # Metro bundler (Expo Go)
 ```
+- Android 에뮬레이터 → 백엔드: `10.0.2.2:8080` 자동 매핑
+- 실기기 테스트 시 `src/constants/config.js`의 네이티브 URL을 PC 로컬 IP로 변경
 
-> ⚠️ Android 에뮬레이터에서 백엔드 접속 시 `10.0.2.2:8080` 사용 (이미 설정됨)
-> 실기기 테스트 시 `src/constants/config.ts`의 IP를 PC 로컬 IP로 변경
+### Frontend (웹)
+```bash
+cd frontend
+npm install
+
+npm run web            # 브라우저에서 Expo Web 미리보기
+npm run build:web      # dist/ 정적 빌드
+```
 
 ---
 
-## 🚫 주의사항
+## 환경변수
 
-- `config.properties` 절대 커밋 금지 (gitignore 처리됨)
-- `main`, `develop` 브랜치 직접 작업 금지
-- 본인 PR 본인 머지 금지
+### Backend (`backend/.env`, mode 600, gitignored)
+```env
+# Supabase PostgreSQL
+SUPABASE_DB_URL=jdbc:postgresql://<supabase-pooler-host>:6543/postgres?prepareThreshold=0
+SUPABASE_DB_USERNAME=postgres.<project-ref>
+SUPABASE_DB_PASSWORD=<rotated-password>
+DB_DRIVER=org.postgresql.Driver
+
+# JWT
+JWT_SECRET=<random-string-at-least-256-bits>
+JWT_ACCESS_EXPIRATION=3600000
+JWT_REFRESH_EXPIRATION=1209600000
+```
+`common/config/EnvConfig.java`의 static 블록에서 앱 기동 시 `Dotenv`로 읽어 `System.setProperty()`로 주입 → `application.properties`의 `${...}` 플레이스홀더가 해석됨.
+
+### Frontend
+`frontend/src/constants/kakao.js`에 Kakao JavaScript 앱 키. API Base URL은 `src/constants/config.js`에 하드코딩 (웹은 `/proxy`, 네이티브는 EC2 IP).
+
+---
+
+## CORS / 공개 경로
+
+### CORS (배포 환경)
+- `http://localhost:5173` (개발)
+- `https://bene-picker.vercel.app`
+- `https://*.vercel.app` (프리뷰)
+
+### 인증 불필요
+- `/api/member/login`, `/api/member/signup`, `/api/member/check-email`, `/api/member/check-nickname`, `/api/member/email/**`
+- `/ws/**`, `/ws-native/**`
+- `/swagger-ui/**`, `/swagger-ui.html`, `/v3/api-docs/**`
+
+---
+
+## 브랜치 전략
+
+```
+main  ← 배포되는 단일 기준 브랜치 (Vercel + EC2 자동 배포)
+ ├── backend      백엔드 작업
+ ├── frontend     모바일·웹 프론트 작업
+ └── fix/*, feat/*, chore/*  단위 작업 브랜치
+```
+
+- 작업 브랜치 → `main` PR → 리뷰 후 머지
+- 본인 PR 본인 머지 지양
+- push 전 `git pull --rebase` 권장
+
+### 커밋 태그
+| 태그 | 의미 | 예 |
+|---|---|---|
+| `[Add]` | 기능 · 파일 추가 | `[Add] 회원가입 API 추가` |
+| `[Fix]` | 버그 수정 | `[Fix] 토큰 만료 401 처리` |
+| `[Update]` | 기능 수정 | `[Update] 로그인 유효성 검사` |
+| `[Delete]` | 제거 | `[Delete] 미사용 util 제거` |
+| `[Chore]` | 설정 · 주석 | `[Chore] gitignore 조정` |
+
+태그 없이도 도메인 prefix(`웹 지도:`, `백엔드 배포:` 등) 형태로 커밋하는 것도 기존 히스토리에 섞여 있음 — 둘 다 허용.
+
+---
+
+## 네이밍 / 주석
+
+### 네이밍
+| 케이스 | 용도 |
+|---|---|
+| `camelCase` | 변수, 함수 |
+| `PascalCase` | 클래스, 컴포넌트, DTO |
+| `UPPER_SNAKE_CASE` | 상수 |
+
+### API 필드 규약 (백엔드 DTO 기준, snake_case 금지)
+- 로그인 요청: `{ memberEmail, memberPw }`
+- 회원가입 요청: `{ memberEmail, memberPw, memberNickname, memberTel? }`
+- 로그인 응답: `{ accessToken, refreshToken }`
+
+### 주석 (필요 시)
+**Backend (JavaDoc)**
+```java
+/**
+ * dev. 이름
+ * 기능 : 회원 정보 조회
+ * @param memberNo 회원 번호
+ * @return Member
+ */
+```
+**Frontend (JSDoc)**
+```javascript
+/**
+ * dev. 이름
+ * 기능 : 로그인 API 호출
+ */
+```
+
+---
+
+## 주의사항
+
+- `backend/.env`, `backend/src/main/resources/config.properties` 절대 커밋 금지 (gitignore 처리됨)
+- `main` 에 직접 푸시하면 그 즉시 프로덕션 배포가 트리거됨 — PR 경유 필수
+- EC2 SSH 키 교체 시 `~/.ssh/authorized_keys` + GitHub Secret `EC2_SSH_KEY` 양쪽 동시 갱신 필요
+- DB 비밀번호·JWT secret 등 민감 값은 **채팅·이슈·PR 본문에 절대 평문 노출 금지** (노출 즉시 Supabase 콘솔에서 로테이트)

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -15,8 +15,14 @@ export function AuthProvider({ children }) {
       const localUri = await AsyncStorage.getItem('profileImageLocalUri');
       const merged = localUri ? { ...res.data, profileImageUrl: localUri } : res.data;
       setUser(merged);
+      return true;
     } catch (e) {
+      if (e?.response?.status === 401) {
+        await AsyncStorage.multiRemove(['accessToken', 'refreshToken', 'profileImageLocalUri']);
+        setToken(null);
+      }
       setUser(null);
+      return false;
     }
   }, []);
 
@@ -28,8 +34,8 @@ export function AuthProvider({ children }) {
         await AsyncStorage.setItem('authResetV1', '1');
       }
       const stored = await AsyncStorage.getItem('accessToken');
-      setToken(stored);
       if (stored) {
+        setToken(stored);
         await fetchUser();
       }
       setIsLoading(false);


### PR DESCRIPTION
## 커밋 2개 묶음

### 1. 로그인 만료 시 자동 로그아웃 처리
`AuthContext.jsx`
- 만료된 토큰으로 앱 재진입 시 홈에 '님' 만 떠 있던 버그:
  - `client.js` 인터셉터가 AsyncStorage 토큰만 지우고 Context state 는 방치
  - 결과적으로 `token=만료된 문자열, user=null` 상태로 AppNavigator 가 계속 렌더됨
- `fetchUser` 에서 401 감지 시 토큰 state 와 AsyncStorage 를 함께 비워 즉시 로그인 화면으로 전환

### 2. README 전면 업데이트
실제 구현과 배포 상태에 맞춰 전면 개편:
- DB 스택 Oracle → PostgreSQL (Supabase) 정정
- 언어 TypeScript → JavaScript 정정
- Vercel(프론트) + EC2(백엔드 systemd) 자동 배포 흐름 문서화
- API 엔드포인트 표 추가 (member / auth / home / map / benefit / search / wish)
- 환경변수 (`backend/.env` + `EnvConfig` dotenv 로드 방식) 설명
- CORS 허용 도메인 / 인증 없이 접근 가능한 경로 명시
- 브랜치 전략을 현재 실제 흐름에 맞게 단순화 (`main` 단일 기준 + 작업 브랜치 PR)

## 영향
- 프론트엔드만 영향 (`frontend/src/context/AuthContext.jsx`)
- README 업데이트는 배포에 영향 없음