### PR TITLE
홈 화면 성능 최적화: 카드 메모이제이션 + 애니메이션 cleanup

### DIFF
--- a/frontend/src/screens/home/HomeScreen.jsx
+++ b/frontend/src/screens/home/HomeScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import {
   View,
   Text,
@@ -96,7 +96,7 @@ const TDAY_STORES = [
 ];
 
 // ── StoreCard ──────────────────────────────────────────────
-function StoreCard({ store, isLiked, onToggleLike, cardWidth }) {
+const StoreCard = memo(function StoreCard({ store, isLiked, onToggleLike, cardWidth }) {
   const pressScale = useRef(new Animated.Value(1)).current;
   const heartScale = useRef(new Animated.Value(1)).current;
 
@@ -110,7 +110,7 @@ function StoreCard({ store, isLiked, onToggleLike, cardWidth }) {
       Animated.spring(heartScale, { toValue: 1.5, useNativeDriver: true, speed: 60 }),
       Animated.spring(heartScale, { toValue: 1, useNativeDriver: true, speed: 40 }),
     ]).start();
-    onToggleLike();
+    onToggleLike(store.id);
   };
 
   return (
@@ -166,10 +166,10 @@ function StoreCard({ store, isLiked, onToggleLike, cardWidth }) {
       </Pressable>
     </Animated.View>
   );
-}
+});
 
 // ── TDayCard ───────────────────────────────────────────────
-function TDayCard({ store }) {
+const TDayCard = memo(function TDayCard({ store }) {
   const pressScale = useRef(new Animated.Value(1)).current;
 
   return (
@@ -207,7 +207,7 @@ function TDayCard({ store }) {
       </Pressable>
     </Animated.View>
   );
-}
+});
 
 // ── HomeScreen ─────────────────────────────────────────────
 export default function HomeScreen() {
@@ -238,21 +238,23 @@ export default function HomeScreen() {
 
   useEffect(() => {
     // 마스코트 떠다니기
-    Animated.loop(
+    const mascotYLoop = Animated.loop(
       Animated.sequence([
         Animated.timing(mascotY,  { toValue: -10, duration: 1600, useNativeDriver: true }),
         Animated.timing(mascotY,  { toValue: 0,   duration: 1600, useNativeDriver: true }),
       ]),
-    ).start();
+    );
+    mascotYLoop.start();
 
     // 마스코트 흔들기
-    Animated.loop(
+    const mascotRotLoop = Animated.loop(
       Animated.sequence([
         Animated.timing(mascotRot, { toValue:  1, duration: 2200, useNativeDriver: true }),
         Animated.timing(mascotRot, { toValue: -1, duration: 2200, useNativeDriver: true }),
         Animated.timing(mascotRot, { toValue:  0, duration: 2200, useNativeDriver: true }),
       ]),
-    ).start();
+    );
+    mascotRotLoop.start();
 
     // 헤더 슬라이드인
     Animated.parallel([
@@ -261,7 +263,7 @@ export default function HomeScreen() {
     ]).start();
 
     // 절약 카드 팝인
-    setTimeout(() => {
+    const t1 = setTimeout(() => {
       Animated.parallel([
         Animated.timing(cardFade,  { toValue: 1, duration: 600, useNativeDriver: true }),
         Animated.spring(cardScale, { toValue: 1, useNativeDriver: true, tension: 70, friction: 8 }),
@@ -270,26 +272,36 @@ export default function HomeScreen() {
 
     // 카운트업 + 프로그레스바
     const lid = savingsAnim.addListener(({ value }) => setDisplayAmt(Math.floor(value)));
-    setTimeout(() => {
+    const t2 = setTimeout(() => {
       Animated.timing(savingsAnim,   { toValue: SAVINGS, duration: 2000, useNativeDriver: false }).start();
       Animated.timing(progressAnim,  { toValue: 1,       duration: 1800, useNativeDriver: false }).start();
     }, 350);
 
-    setTimeout(() => {
+    const t3 = setTimeout(() => {
       Animated.parallel([
         Animated.timing(sec1Fade,  { toValue: 1, duration: 600, useNativeDriver: true }),
         Animated.timing(sec1Slide, { toValue: 0, duration: 500, useNativeDriver: true }),
       ]).start();
     }, 550);
 
-    setTimeout(() => {
+    const t4 = setTimeout(() => {
       Animated.parallel([
         Animated.timing(sec2Fade,  { toValue: 1, duration: 600, useNativeDriver: true }),
         Animated.timing(sec2Slide, { toValue: 0, duration: 500, useNativeDriver: true }),
       ]).start();
     }, 750);
 
-    return () => savingsAnim.removeListener(lid);
+    return () => {
+      mascotYLoop.stop();
+      mascotRotLoop.stop();
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+      clearTimeout(t4);
+      savingsAnim.removeListener(lid);
+      savingsAnim.stopAnimation();
+      progressAnim.stopAnimation();
+    };
   }, []);
 
   const progressWidth = progressAnim.interpolate({
@@ -302,13 +314,13 @@ export default function HomeScreen() {
     outputRange: ['-4deg', '0deg', '4deg'],
   });
 
-  const toggleLike = (id) => {
+  const toggleLike = useCallback((id) => {
     setLikedIds(prev => {
       const next = new Set(prev);
       next.has(id) ? next.delete(id) : next.add(id);
       return next;
     });
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -400,7 +412,7 @@ export default function HomeScreen() {
                 key={store.id}
                 store={store}
                 isLiked={likedIds.has(store.id)}
-                onToggleLike={() => toggleLike(store.id)}
+                onToggleLike={toggleLike}
                 cardWidth={cardWidth}
               />
             ))}


### PR DESCRIPTION
## Summary
- `StoreCard` / `TDayCard`를 `React.memo`로 래핑하여 좋아요 토글 시 4개 카드 모두 리렌더되던 문제 해결
- `toggleLike`를 `useCallback`으로 안정화하고 부모의 인라인 arrow 제거
- `useEffect` cleanup에서 마스코트 `Animated.loop` 2개, `setTimeout` 4개, `savings`/`progress` 애니메이션 정지 추가 (홈 화면 언마운트 시 백그라운드 애니메이션·메모리 누수 방지)

## Test plan
- [ ] `npx expo start` 후 홈 진입
- [ ] 카드 좋아요 토글 시 해당 카드 1장만 리렌더되는지 (React DevTools Highlight Updates 또는 Profiler)
- [ ] 홈 → 검색/마이페이지 → 홈 5회 왕복 후 마스코트 애니메이션 가속 없음 / `setState on unmounted` 경고 없음
- [ ] 절약 카드 카운트업, 마스코트 떠다님·회전, T데이 카드 press 애니메이션 등 회귀 없음